### PR TITLE
fix/const declarations for 1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,18 +2,18 @@ plugins {
     id 'java'
 }
 
-// TODO: uncomment to be able to fetch packages in your own repository
 repositories {
     mavenLocal()
     mavenCentral()
-    maven {
-        name = "GitHubPackages"
-        url = uri("https://maven.pkg.github.com/<your-username>/printscript")
-        credentials {
-            username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
-            password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
-        }
-    }
+// TODO: uncomment to be able to fetch packages in your own repository
+//    maven {
+//        name = "GitHubPackages"
+//        url = uri("https://maven.pkg.github.com/<your-username>/printscript")
+//        credentials {
+//            username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
+//            password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
+//        }
+//    }
 }
 
 java {

--- a/src/test/java/formatter/FormatterTest.java
+++ b/src/test/java/formatter/FormatterTest.java
@@ -42,7 +42,7 @@ public class FormatterTest {
 
     @Parameterized.Parameters(name = "version {0} - {1}")
     public static Collection<Object[]> data() {
-        return collectTestSet(basePath, filePicker());
+        return collectTestSet(basePath, true, filePicker());
     }
 
     @Test

--- a/src/test/java/interpreter/InterpreterValidationTest.java
+++ b/src/test/java/interpreter/InterpreterValidationTest.java
@@ -42,7 +42,8 @@ public class InterpreterValidationTest {
 
     @Parameterized.Parameters(name = "version {0} - {1})")
     public static Collection<Object[]> data() {
-        return collectTestSet(basePath);
+        // We don't want tests from previous versions as they are already duplicate. We will have to change this if there ever is a version 1.2
+        return collectTestSet(basePath, false);
     }
 
     @Test

--- a/src/test/java/linter/LinterTest.java
+++ b/src/test/java/linter/LinterTest.java
@@ -45,7 +45,7 @@ public class LinterTest {
 
     @Parameterized.Parameters(name = "version {0} - {1}")
     public static Collection<Object[]> data() {
-        return collectTestSet(basePath, filePicker());
+        return collectTestSet(basePath, false, filePicker());
     }
 
     @Test

--- a/src/test/java/util/SuiteOps.java
+++ b/src/test/java/util/SuiteOps.java
@@ -38,8 +38,8 @@ public class SuiteOps {
         return test.resolve(name).toFile();
     }
 
-    public static Collection<Object[]> collectTestSet(String basePath) {
-        return collectTestSet(basePath, (base, version) -> {
+    public static Collection<Object[]> collectTestSet(String basePath, boolean addTestsFromPreviousVersions) {
+        return collectTestSet(basePath, addTestsFromPreviousVersions, (base, version) -> {
             try {
                 return getFilesForVersion(base, version, collectFiles());
             } catch (IOException e) {
@@ -54,11 +54,13 @@ public class SuiteOps {
     }
 
 
-    public static Collection<Object[]> collectTestSet(String basePath, BiFunction<String, String, List<Object[]>> filePicker) {
+    public static Collection<Object[]> collectTestSet(String basePath, boolean addTestsFromPreviousVersions, BiFunction<String, String, List<Object[]>> filePicker) {
         final List<Object[]> result = new java.util.ArrayList<>(List.of());
         final List<Object[]> version1 = filePicker.apply(basePath, "1.0");
         result.addAll(version1);
-        result.addAll(reversion("1.1", version1));
+        if (addTestsFromPreviousVersions) {
+            result.addAll(reversion("1.1", version1));
+        }
         result.addAll(filePicker.apply(basePath, "1.1"));
         return result;
     }

--- a/src/test/resources/validation/1.0/invalid-if-statement.ps
+++ b/src/test/resources/validation/1.0/invalid-if-statement.ps
@@ -1,4 +1,4 @@
-let a: boolean = 2 > 1;
+let a: number = 21;
 if(a) {
     println("if should not be supported in version 1.0");
 }

--- a/src/test/resources/validation/1.1/invalid-const-declaration.ps
+++ b/src/test/resources/validation/1.1/invalid-const-declaration.ps
@@ -1,1 +1,0 @@
-const a: string = "constant declaration should not be allowed in version 1.0";

--- a/src/test/resources/validation/1.1/invalid-if-statement.ps
+++ b/src/test/resources/validation/1.1/invalid-if-statement.ps
@@ -1,4 +1,0 @@
-let a: boolean = 2 > 1;
-if(a) {
-    println("if should not be supported in version 1.0");
-}


### PR DESCRIPTION
This incorporates changes from @inesgassiebayle in #51. That PR was closed as a bigger change is needed

- (fix): changed boolean to number so that tests errors out when it encounters the if. Otherwise it will throw an error when it encounters 'boolean'
- (fix): only comment custom repository in build so that it can be run
- (feat/fix): customize wether or not a suite given a version runs previous version's tests also to fix wrong test in validation 1.1 suite
